### PR TITLE
Fix arXiv util bugs

### DIFF
--- a/scoap3/utils/arxiv.py
+++ b/scoap3/utils/arxiv.py
@@ -66,8 +66,13 @@ def get_arxiv_categories(arxiv_id):
     if data.status_code == 200:
         xml = etree.fromstring(data.content)
         primary_category = xml.xpath('//arxiv:primary_category/@term', namespaces=xml_namespaces)
+
+        if not primary_category:
+            logger.error('Arxiv did not return primary category for id: %s' % arxiv_id)
+            return categories
+
         if len(primary_category) > 1:
-            logger.error('Arxiv returned %d primary categories for id: %s' % (len(primary_category), arxiv_id))
+            logger.error('Arxiv returned %d primary category for id: %s' % (len(primary_category), arxiv_id))
 
         secondary_categories = xml.xpath('//w3:category/@term', namespaces=xml_namespaces)
 

--- a/scoap3/utils/arxiv.py
+++ b/scoap3/utils/arxiv.py
@@ -44,10 +44,10 @@ def get_clean_arXiv_id(record):
 
 
 def clean_arxiv(arxiv):
-    # drop 'arxiv:' prefix and version
+    # drop 'arxiv:' prefix, version and other information if there is
     if arxiv is None:
         return None
-    return arxiv.split(':')[-1].split('v')[0]
+    return arxiv.split(':')[-1].split('v')[0].split(' ')[0]
 
 
 def get_arxiv_categories(arxiv_id):

--- a/scoap3/utils/arxiv.py
+++ b/scoap3/utils/arxiv.py
@@ -45,9 +45,11 @@ def get_clean_arXiv_id(record):
 
 def clean_arxiv(arxiv):
     # drop 'arxiv:' prefix, version and other information if there is
+    # also force ascii encoding and strip unnecessary characters
     if arxiv is None:
         return None
-    return arxiv.split(':')[-1].split('v')[0].split(' ')[0]
+
+    return arxiv.split(':')[-1].split('v')[0].split(' ')[0].encode('ascii').strip('"\'')
 
 
 def get_arxiv_categories(arxiv_id):

--- a/tests/responses/arxiv/empty.xml
+++ b/tests/responses/arxiv/empty.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <link href="http://arxiv.org/api/query?search_query%3Did%3Anot_found%26id_list%3D%26start%3D0%26max_results%3D10" rel="self" type="application/atom+xml"/>
+  <title type="html">ArXiv Query: search_query=id:not_found&amp;id_list=&amp;start=0&amp;max_results=10</title>
+  <id>http://arxiv.org/api/103daAii6jdz1xC0P3OUOW1O9yU</id>
+  <updated>2019-03-14T00:00:00-04:00</updated>
+  <opensearch:totalResults xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">0</opensearch:totalResults>
+  <opensearch:startIndex xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">0</opensearch:startIndex>
+  <opensearch:itemsPerPage xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">10</opensearch:itemsPerPage>
+</feed>

--- a/tests/unit/utils/test_arxiv.py
+++ b/tests/unit/utils/test_arxiv.py
@@ -42,3 +42,11 @@ def test_extract_arxiv_id_complex():
 def test_extract_arxiv_none():
     """Test for None param."""
     assert clean_arxiv(None) is None
+
+
+def test_extract_arxiv_with_categ():
+    """
+    Test for arxiv with category.
+    Delivered for article: 10.1140/epjc/s10052-019-6679-6
+    """
+    assert clean_arxiv('arXiv:1803.07217 [gr-qc]') == '1803.07217'

--- a/tests/unit/utils/test_arxiv.py
+++ b/tests/unit/utils/test_arxiv.py
@@ -19,6 +19,19 @@ def test_categories():
             assert categories == ['hep-th', 'gr-qc', 'math-ph', 'math.MP']
 
 
+def test_empty_response():
+    """Test extraction arXiv categories from arXiv api."""
+
+    file_path = path.join(get_response_dir(), 'arxiv', 'empty.xml')
+    with open(file_path, 'rb') as f:
+        file_data = f.read()
+
+        with requests_mock.Mocker() as m:
+            m.get('http://export.arxiv.org/api/query?search_query=id:not_found', text=file_data)
+            categories = get_arxiv_categories('not_found')
+            assert categories == []
+
+
 def test_extract_arxiv_id():
     """Test getting clean arXiv identifier."""
     assert clean_arxiv('12356.78') == '12356.78'

--- a/tests/unit/utils/test_arxiv.py
+++ b/tests/unit/utils/test_arxiv.py
@@ -1,6 +1,7 @@
 from os import path
 
 import requests_mock
+from pytest import raises
 
 from scoap3.utils.arxiv import get_arxiv_categories, clean_arxiv
 from tests.responses import get_response_dir
@@ -63,3 +64,12 @@ def test_extract_arxiv_with_categ():
     Delivered for article: 10.1140/epjc/s10052-019-6679-6
     """
     assert clean_arxiv('arXiv:1803.07217 [gr-qc]') == '1803.07217'
+
+
+def test_extract_arxiv_additional_chars():
+    """
+    Test getting clean arXiv identifier with additional chars.
+    Delivered for article: 10.1140/epjc/s10052-018-6500-y
+    """
+    with raises(UnicodeEncodeError):
+        clean_arxiv(u'"1808.01899\u201c')


### PR DESCRIPTION
Handle the following cases:
* category appears in id
* arxiv id not found, "empty" xml response from arXiv
* unicode chars in id (malformatted arxiv id)