### PR TITLE
remove record_creation_date and year from ui

### DIFF
--- a/scoap3/config.py
+++ b/scoap3/config.py
@@ -90,9 +90,9 @@ RECORDS_UI_ENDPOINTS = dict(
 )
 RECORDS_REST_SORT_OPTIONS = {
     "records-record": {
-        "record_creation_date": {
+        "date": {
             "title": 'Most recent',
-            "fields": ['record_creation_date'],
+            "fields": ['date'],
             "default_order": 'desc',
             "order": 1,
         },
@@ -108,8 +108,8 @@ RECORDS_REST_SORT_OPTIONS = {
 #: Default sort for records REST API.
 RECORDS_REST_DEFAULT_SORT = {
     "records-record": {
-        'query': '-record_creation_date',
-        'noquery': '-record_creation_date'
+        'query': '-date',
+        'noquery': '-date'
     },
 }
 
@@ -119,8 +119,8 @@ RECORDS_REST_FACETS = {
             "journal": terms_filter("publication_info.journal_title"),
             "country": terms_filter_with_must("authors.affiliations.country"),
             "collaboration": terms_filter("facet_collaboration"),
-            "record_creation_date": range_filter(
-                'record_creation_date',
+            "year": range_filter(
+                'year',
                 format='yyyy',
                 end_date_math='/y')
         },
@@ -145,9 +145,9 @@ RECORDS_REST_FACETS = {
                     "size": 20
                 }
             },
-            "record_creation_date": {
+            "year": {
                 "date_histogram": {
-                    "field": "record_creation_date",
+                    "field": "year",
                     "interval": "year",
                     "format": "yyyy",
                     "min_doc_count": 1

--- a/scoap3/modules/api/templates/scoap3_api/email/confirmed.html
+++ b/scoap3/modules/api/templates/scoap3_api/email/confirmed.html
@@ -1,6 +1,8 @@
 Dear {{ recipient }},
 
-<p>Your registration to SCOAP3 API was accepted. Please find you login detiles below. Please remember to change the password after you login at <a href="beta.scoap3.org/login">beta.scoap3.org/login</a><p>
+<p>
+    Your registration to SCOAP3 API was accepted. Please find you login details below. Please remember to change the password after you login at <a href="beta.scoap3.org/login">beta.scoap3.org/login</a>
+<p>
 
 <p>
     Login: {{ email }}<br>
@@ -8,7 +10,8 @@ Dear {{ recipient }},
 </p>
 
 <p>
-    Documentation on how to use API can be found at <a href='http://scoap3.org/scoap3-repository/xml-api#key'>SCOAP3 XML API</a>.</p>
+    Documentation on how to use API can be found <a href='https://github.com/SCOAP3/scoap3-next/wiki'>here</a>.
+</p>
 
-With kind regards,
+With kind regards,<br />
 The SCOAP3 Team

--- a/scoap3/modules/records/__init__.py
+++ b/scoap3/modules/records/__init__.py
@@ -3,3 +3,5 @@ from .permissions import record_read_permission_factory, RecordPermission
 
 __all__ = ['Scoap3Records', 'record_read_permission_factory',
            'RecordPermission']
+
+from . import receivers  # noqa 401

--- a/scoap3/modules/records/jsonschemas/hep.json
+++ b/scoap3/modules/records/jsonschemas/hep.json
@@ -83,10 +83,6 @@
                 }
             }
         },
-        "record_creation_year": {
-            "type": "integer",
-            "description": "Year part of record_creation_date. Probably will be deleted."
-        },
         "record_creation_date": {
             "type": "string",
             "format": "date-time"

--- a/scoap3/modules/records/mappings/records/record.json
+++ b/scoap3/modules/records/mappings/records/record.json
@@ -64,17 +64,7 @@
                 },
                 "record_creation_date": {
                     "type": "date",
-                    "format": "yyyy||yyyy-MM||yyyy-MM-dd||yyyy-MM-dd'T'HH:mm:ss.SSSSSS||yyyy-MM-dd'T'HH:mm:ss",
-                    "copy_to": "date"
-                },
-                "record_creation_year": {
-                    "type": "date",
-                    "format": "yyyy",
-                    "copy_to": "year"
-                },
-                "year": {
-                    "index": "analyzed",
-                    "type": "date"
+                    "format": "yyyy||yyyy-MM||yyyy-MM-dd||yyyy-MM-dd'T'HH:mm:ss.SSSSSS||yyyy-MM-dd'T'HH:mm:ss"
                 },
                 "titles": {
                     "properties":{
@@ -120,18 +110,24 @@
                     "index": "analyzed",
                     "type": "date"
                 },
-                "doi":{
+                "doi": {
                     "index": "not_analyzed",
                     "type": "string"
                 },
-                "imprints":{
+                "imprints": {
                     "properties": {
                         "date": {
                             "format": "yyyy||yyyy-MM||yyyy-MM-dd",
-                            "type": "date"
+                            "type": "date",
+                            "copy_to": "date"
                         }
                     },
                     "type": "object"
+                },
+                "year": {
+                    "index": "analyzed",
+                    "type": "date",
+                    "format": "yyyy"
                 }
             }
         }

--- a/scoap3/modules/records/receivers.py
+++ b/scoap3/modules/records/receivers.py
@@ -1,0 +1,35 @@
+from elasticsearch import NotFoundError
+from flask import current_app
+from flask_sqlalchemy import models_committed
+from inspire_utils.record import get_value
+from invenio_indexer.api import RecordIndexer
+from invenio_indexer.signals import before_record_index
+from invenio_records import Record
+from invenio_records.models import RecordMetadata
+
+
+@before_record_index.connect
+def enchance_before_index(sender, json, *args, **kwargs):
+    """Enchance record data for indexing"""
+
+    publication_date = get_value(json, 'imprints[0].date')
+    if publication_date:
+        json['year'] = publication_date[:4]
+
+
+@models_committed.connect
+def index_after_commit(sender, changes):
+    """Index records automatically after each modification."""
+
+    indexer = RecordIndexer()
+    for model_instance, change in changes:
+        if isinstance(model_instance, RecordMetadata):
+            if change in ('insert', 'update') and model_instance.json:
+                indexer.index(Record(model_instance.json, model_instance))
+            else:
+                try:
+                    indexer.delete(Record(model_instance.json, model_instance))
+                except NotFoundError:
+                    # Record not found in ES
+                    current_app.logger.warning('Record with id "%s" not found in ElasticSearch' %
+                                               model_instance.json.get('control_number'))

--- a/scoap3/modules/search/static/templates/scoap3_search/default.html
+++ b/scoap3/modules/search/static/templates/scoap3_search/default.html
@@ -10,7 +10,7 @@
           ; et al
           </span>
         </i>
-        <small class="search-record-list-date"> - {{ record.metadata.record_creation_date.split('T')[0] }}</small>
+        <small class="search-record-list-date"> - {{ record.metadata.imprints[0].date }}</small>
     </p>
     <p ng-repeat='abstract in record.metadata.abstracts'>
       <span ng-bind-html="abstract.value | limitTo:600 | safe"></span>

--- a/scoap3/modules/search/static/templates/scoap3_search/facets.html
+++ b/scoap3/modules/search/static/templates/scoap3_search/facets.html
@@ -1,6 +1,6 @@
 <div ng-init="titles={'country': 'Country', 'journal': 'Journal'};limit=10">
   <div ng-init="tree=[];tree_more=[]" ng-repeat="(key, value) in vm.invenioSearchResults.aggregations track by $index">
-    <div ng-if="value.buckets.length > 0 && key != 'record_creation_date'" class="panel panel-default">
+    <div ng-if="value.buckets.length > 0 && key != 'year'" class="panel panel-default">
       <div class="panel-heading">
         <a name="anchor_{{ key }}"></a>
         <h3 class="panel-title">{{ titles[key] }}</h3>

--- a/scoap3/modules/search/static/templates/scoap3_search/range.html
+++ b/scoap3/modules/search/static/templates/scoap3_search/range.html
@@ -1,8 +1,8 @@
-<div class="panel panel-default" ng-show="vm.invenioSearchResults.aggregations.record_creation_date.buckets.length > 0">
+<div class="panel panel-default" ng-show="vm.invenioSearchResults.aggregations.year.buckets.length > 0">
     <div class="panel-heading">
         <h3 class="panel-title">Year</h3>
     </div>
-    <span class="pull-right" ng-show="vm.invenioSearchArgs['record_creation_date'] && vm.invenioSearchArgs.record_creation_date.length > 0">
+    <span class="pull-right" ng-show="vm.invenioSearchArgs['year'] && vm.invenioSearchArgs.year.length > 0">
           <a class="reset-button btn btn-primary btn-sm" ng-click="resetRangeSelection()">Reset</a>
     </span>
     <div class="panel-body">

--- a/scoap3/modules/search/templates/scoap3_search/search.html
+++ b/scoap3/modules/search/templates/scoap3_search/search.html
@@ -141,7 +141,7 @@
     {%- block search_facets %}
     <div class="col-md-3 col-md-pull-9 col-xs-12">
       <invenio-search-range
-        options='{"histogramId": "#year_hist", "selectionId": "#year_select", "name": "record_creation_date", "width": 180}'
+        options='{"histogramId": "#year_hist", "selectionId": "#year_select", "name": "year", "width": 180}'
         template="{{ url_for('static', filename=config.SEARCH_UI_JSTEMPLATE_RANGE_FACET) }}">
       </invenio-search-range>
       <invenio-search-facets

--- a/tests/integration/test_article_upload.py
+++ b/tests/integration/test_article_upload.py
@@ -1,42 +1,14 @@
-import json
-import re
-from os import path
-
 import requests_mock
-from invenio_pidstore.models import PersistentIdentifier
-from invenio_records import Record
 from invenio_workflows import Workflow
-from mock import patch
 from workflow.engine_db import WorkflowStatus
-from workflow.errors import HaltProcessing
 
-from scoap3.modules.records.util import create_from_json
-from tests.responses import get_response_dir, read_hep_schema, read_titles_schema, read_response
-
-
-def _get_record_from_workflow(workflow):
-    assert len(workflow.objects) == 1
-    workflow_object = workflow.objects[0]
-
-    recid = workflow_object.data['control_number']
-    pid = PersistentIdentifier.get('recid', recid)
-
-    return Record.get_record(pid.object_uuid)
-
-
-def _read_hepcrawl_response_from_json(input_json_filename):
-    file_path = path.join(get_response_dir(), 'hepcrawl', input_json_filename)
-    with open(file_path, 'rt') as f:
-        return json.loads(f.read())
-
-
-def mock_halt(msg, eng):
-    raise HaltProcessing(msg)
+from tests.integration.utils import get_record_from_workflow, run_article_upload_with_data, run_article_upload_with_file
+from tests.responses import read_response, read_response_as_json
 
 
 def test_halt_record_without_authors():
     # read article data from json
-    json_data = _read_hepcrawl_response_from_json('aps2.json')
+    json_data = read_response_as_json('hepcrawl', 'aps2.json')
 
     # delete authors
     json_data.pop('authors')
@@ -46,14 +18,14 @@ def test_halt_record_without_authors():
         m.get('http://export.arxiv.org/api/query?search_query=id:1808.08188',
               content=read_response('article_upload', 'export.arxiv.org_api_query_search_query_id_1808.08188'))
 
-        workflow = run_workflow_with_data(json_data, m)
+        workflow = run_article_upload_with_data(json_data, m)
         assert workflow.status == WorkflowStatus.HALTED
         assert workflow.objects[0].extra_data['_message'] == 'No authors for article.'
 
 
 def test_halt_record_without_affiliations():
     # read article data from json
-    json_data = _read_hepcrawl_response_from_json('aps2.json')
+    json_data = read_response_as_json('hepcrawl', 'aps2.json')
 
     author_count = len(json_data.get('authors', ()))
     assert author_count > 0
@@ -67,7 +39,7 @@ def test_halt_record_without_affiliations():
         m.get('http://export.arxiv.org/api/query?search_query=id:1808.08188',
               content=read_response('article_upload', 'export.arxiv.org_api_query_search_query_id_1808.08188'))
 
-        workflow = run_workflow_with_data(json_data, m)
+        workflow = run_article_upload_with_data(json_data, m)
         assert workflow.status == WorkflowStatus.HALTED
         assert workflow.objects[0].extra_data['_message'] == (
             "No affiliations for author: {u'raw_name': u'We-Fu Chang', u'surname': u'Chang', u'given_names': u'We-Fu', "
@@ -77,7 +49,7 @@ def test_halt_record_without_affiliations():
 
 def test_halt_invalid_record():
     # read article data from json
-    json_data = _read_hepcrawl_response_from_json('aps2.json')
+    json_data = read_response_as_json('hepcrawl', 'aps2.json')
 
     # delete a required field to fail the validation
     json_data.pop('abstracts')
@@ -95,7 +67,7 @@ def test_halt_invalid_record():
         m.get('https://api.crossref.org/works/10.1103/PhysRevD.99.075025',
               content=read_response('article_upload', 'crossref.org_works_10.1103_PhysRevD.99.075025'))
 
-        workflow = run_workflow_with_data(json_data, m)
+        workflow = run_article_upload_with_data(json_data, m)
         assert workflow.status == WorkflowStatus.HALTED
         assert workflow.objects[0].extra_data['_message'].startswith("Validation error: u'abstracts' is a "
                                                                      "required property")
@@ -121,11 +93,11 @@ def test_record_update():
               content=read_response('article_upload', 'crossref.org_works_10.1103_PhysRevD.99.075025'))
 
         # read article data from json
-        json_data = _read_hepcrawl_response_from_json('aps2.json')
+        json_data = read_response_as_json('hepcrawl', 'aps2.json')
 
         # run first workflow
-        workflow1 = run_workflow_with_data(json_data, m)
-        record1 = _get_record_from_workflow(workflow1)
+        workflow1 = run_article_upload_with_data(json_data, m)
+        record1 = get_record_from_workflow(workflow1)
         assert workflow1.status == WorkflowStatus.COMPLETED
 
         # update article data
@@ -133,8 +105,8 @@ def test_record_update():
         updated_json_data['titles'][0]['title'] = 'Manually updated title'
 
         # run second workflow
-        workflow2 = run_workflow_with_data(updated_json_data, m)
-        record2 = _get_record_from_workflow(workflow2)
+        workflow2 = run_article_upload_with_data(updated_json_data, m)
+        record2 = get_record_from_workflow(workflow2)
         assert workflow2.status == WorkflowStatus.COMPLETED
 
         # control number should be the same, but article data has to be updated
@@ -163,11 +135,11 @@ def test_invalid_record_update_with_whole_workflow():
               content=read_response('article_upload', 'crossref.org_works_10.1103_PhysRevD.99.075025'))
 
         # read article data from json
-        json_data = _read_hepcrawl_response_from_json('aps2.json')
+        json_data = read_response_as_json('hepcrawl', 'aps2.json')
 
         # run first workflow
-        workflow1 = run_workflow_with_data(json_data, m)
-        record1 = _get_record_from_workflow(workflow1)
+        workflow1 = run_article_upload_with_data(json_data, m)
+        record1 = get_record_from_workflow(workflow1)
         assert workflow1.status == WorkflowStatus.COMPLETED
 
         # update article data
@@ -178,8 +150,8 @@ def test_invalid_record_update_with_whole_workflow():
         updated_json_data.pop('abstracts')
 
         # run second workflow
-        workflow2 = run_workflow_with_data(updated_json_data, m)
-        record2 = _get_record_from_workflow(workflow2)
+        workflow2 = run_article_upload_with_data(updated_json_data, m)
+        record2 = get_record_from_workflow(workflow2)
         assert workflow2.status == WorkflowStatus.HALTED
         assert workflow2.objects[0].extra_data['_message'].startswith("Validation error: u'abstracts' is a "
                                                                       "required property")
@@ -189,31 +161,6 @@ def test_invalid_record_update_with_whole_workflow():
         assert record1['titles'][0]['title'] == 'Alternative perspective on gauged lepton number and implications ' \
                                                 'for collider physics'
         assert record1['titles'][0]['title'] == record2['titles'][0]['title']
-
-
-def run_workflow_with_file(input_json_filename, mock_address):
-    """Uses input_json_filename to load hepcrawl response and to run article_upload workflow.
-    Returns the Workflow object."""
-
-    json_data = _read_hepcrawl_response_from_json(input_json_filename)
-    return run_workflow_with_data(json_data, mock_address)
-
-
-def run_workflow_with_data(input_json_data, mock_address):
-    """Runs article_upload workflow with input_json_data.
-    Returns the Workflow object."""
-
-    with patch('scoap3.modules.workflows.workflows.articles_upload.__halt_and_notify', mock_halt):
-        mock_address.register_uri('GET', '/schemas/hep.json', content=read_hep_schema())
-        mock_address.register_uri('GET', '/schemas/elements/titles.json', content=read_titles_schema())
-        mock_address.register_uri(
-            requests_mock.ANY,
-            re.compile('.*(indexer).*'),
-            real_http=True,
-        )
-        workflow_id = create_from_json({'records': [input_json_data]}, apply_async=False)[0]
-
-    return Workflow.query.get(workflow_id)
 
 
 def test_hindawi():
@@ -226,12 +173,12 @@ def test_hindawi():
               content=read_response('article_upload', 'hindawi.com_journals_ahep_2019_4123108.xml'))
         m.get('https://api.crossref.org/works/10.1155/2019/4123108',
               content=read_response('article_upload', 'crossref.org_works_10.1155_2019_4123108'))
-        workflow = run_workflow_with_file('hindawi.json', m)
+        workflow = run_article_upload_with_file('hindawi.json', m)
 
     assert workflow.status == WorkflowStatus.COMPLETED
     assert Workflow.query.count() - workflows_count == 1
 
-    record = _get_record_from_workflow(workflow)
+    record = get_record_from_workflow(workflow)
     assert len(record['_files']) == 2
     assert record['_oai']['sets'] == ['AHEP']
     assert record['abstracts'][0]['value'] == ''
@@ -292,12 +239,12 @@ def test_hindawi2():
               content=read_response('article_upload', 'hindawi.com_journals_ahep_2014_191960.xml'))
         m.get('https://api.crossref.org/works/10.1155/2014/191960',
               content=read_response('article_upload', 'crossref.org_works_10.1155_2014_191960'))
-        workflow = run_workflow_with_file('hindawi2.json', m)
+        workflow = run_article_upload_with_file('hindawi2.json', m)
 
     assert workflow.status == WorkflowStatus.COMPLETED
     assert Workflow.query.count() - workflows_count == 1
 
-    record = _get_record_from_workflow(workflow)
+    record = get_record_from_workflow(workflow)
     assert len(record['_files']) == 2
     assert record['_oai']['sets'] == ['AHEP']
     assert record['abstracts'][0]['value'] == 'In the last decades, a very [...] solutions in the near future.'
@@ -385,12 +332,12 @@ def test_aps():
                        content=read_response('article_upload', 'harvest.aps.org_PhysRevD.99.045009.xml'))
         m.get('https://api.crossref.org/works/10.1103/PhysRevD.99.045009',
               content=read_response('article_upload', 'crossref.org_works_10.1103_PhysRevD.99.045009'))
-        workflow = run_workflow_with_file('aps.json', m)
+        workflow = run_article_upload_with_file('aps.json', m)
 
     assert workflow.status == WorkflowStatus.COMPLETED
     assert Workflow.query.count() - workflows_count == 1
 
-    record = _get_record_from_workflow(workflow)
+    record = get_record_from_workflow(workflow)
     assert len(record['_files']) == 2
     assert record['_oai']['sets'] == ['PRD']
     assert record['abstracts'][0]['value'] == (
@@ -458,12 +405,12 @@ def test_aps_with_collaboration():
                        content=read_response('article_upload', 'harvest.aps.org_PhysRevD.97.012001.xml'))
         m.get('https://api.crossref.org/works/10.1103/PhysRevD.97.012001',
               content=read_response('article_upload', 'crossref.org_works_10.1103_PhysRevD.97.012001'))
-        workflow = run_workflow_with_file('aps3.json', m)
+        workflow = run_article_upload_with_file('aps3.json', m)
 
     assert workflow.status == WorkflowStatus.COMPLETED
     assert Workflow.query.count() - workflows_count == 1
 
-    record = _get_record_from_workflow(workflow)
+    record = get_record_from_workflow(workflow)
     assert record['collaborations'] == [{"value": "T2K Collaboration"}]
 
 
@@ -473,12 +420,12 @@ def test_elsevier():
     with requests_mock.Mocker() as m:
         m.get('https://api.crossref.org/works/10.1016/j.nuclphysb.2018.07.004',
               content=read_response('article_upload', 'crossref.org_works_10.1016_j.nuclphysb.2018.07.004'))
-        workflow = run_workflow_with_file('elsevier/elsevier.json', m)
+        workflow = run_article_upload_with_file('elsevier/elsevier.json', m)
 
     assert workflow.status == WorkflowStatus.COMPLETED
     assert Workflow.query.count() - workflows_count == 1
 
-    record = _get_record_from_workflow(workflow)
+    record = get_record_from_workflow(workflow)
     assert len(record['_files']) == 2
     assert record['_oai']['sets'] == ['NPB']
     assert record['abstracts'][0]['value'] == (
@@ -520,12 +467,12 @@ def test_springer():
               content=read_response('article_upload', 'export.arxiv.org_api_query_search_query_id:1810.09837'))
         m.get('https://api.crossref.org/works/10.1140/epjc/s10052-019-6572-3',
               content=read_response('article_upload', 'crossref.org_works_10.1140_epjc_s10052-019-6572-3'))
-        workflow = run_workflow_with_file('springer/springer.json', m)
+        workflow = run_article_upload_with_file('springer/springer.json', m)
 
     assert workflow.status == WorkflowStatus.COMPLETED
     assert Workflow.query.count() - workflows_count == 1
 
-    record = _get_record_from_workflow(workflow)
+    record = get_record_from_workflow(workflow)
     assert len(record['_files']) == 2
     assert record['_oai']['sets'] == ['EPJC']
     assert record['abstracts'][0]['value'] == (
@@ -592,12 +539,12 @@ def test_oup():
               content=read_response('article_upload', 'export.arxiv.org_api_query_search_query_id:1611.10151'))
         m.get('https://api.crossref.org/works/10.1093/ptep/pty143',
               content=read_response('article_upload', 'crossref.org_works_10.1093_ptep_pty143'))
-        workflow = run_workflow_with_file('oup/oup.json', m)
+        workflow = run_article_upload_with_file('oup/oup.json', m)
 
     assert workflow.status == WorkflowStatus.COMPLETED
     assert Workflow.query.count() - workflows_count == 1
 
-    record = _get_record_from_workflow(workflow)
+    record = get_record_from_workflow(workflow)
     assert len(record['_files']) == 3
     assert record['_oai']['sets'] == ['PTEP']
     assert record['abstracts'][0]['value'] == (

--- a/tests/integration/test_robotupload.py
+++ b/tests/integration/test_robotupload.py
@@ -6,14 +6,10 @@ from flask import current_app
 from mock import patch
 from invenio_workflows import Workflow
 from workflow.engine_db import WorkflowStatus
-from workflow.errors import HaltProcessing
 
 from scoap3.modules.robotupload.views import handle_upload_request
+from tests.integration.utils import mock_halt
 from tests.responses import get_response_dir, read_response
-
-
-def mock_halt(msg, eng):
-    raise HaltProcessing(msg)
 
 
 def load_schema(name):

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -1,0 +1,19 @@
+import json
+from urllib import quote
+
+from inspire_utils.record import get_value
+
+
+def test_year_field(app_client, test_record):
+    assert test_record['record_creation_date'] == '2019-02-21T14:38:42.640699'
+    assert 'year' not in test_record
+
+    doi = get_value(test_record, 'dois[0].value')
+    search_param = '"%s"' % doi
+
+    response = app_client.get('/api/records/?q=%s' % quote(search_param))
+    data = json.loads(response.data)
+
+    record = data['hits']['hits'][0]['metadata']
+    assert 'year' in record
+    assert record['year'] == record['imprints'][0]['date'][:4]

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,0 +1,50 @@
+import re
+
+import requests_mock
+from invenio_pidstore.models import PersistentIdentifier
+from invenio_records import Record
+from invenio_workflows import Workflow
+from mock import patch
+from workflow.errors import HaltProcessing
+
+from scoap3.modules.records.util import create_from_json
+from tests.responses import read_hep_schema, read_titles_schema, read_response_as_json
+
+
+def mock_halt(msg, eng):
+    raise HaltProcessing(msg)
+
+
+def run_article_upload_with_file(input_json_filename, mock_address):
+    """Uses input_json_filename to load hepcrawl response and to run article_upload workflow.
+    Returns the Workflow object."""
+
+    json_data = read_response_as_json('hepcrawl', input_json_filename)
+    return run_article_upload_with_data(json_data, mock_address)
+
+
+def run_article_upload_with_data(input_json_data, mock_address):
+    """Runs article_upload workflow with input_json_data.
+    Returns the Workflow object."""
+
+    with patch('scoap3.modules.workflows.workflows.articles_upload.__halt_and_notify', mock_halt):
+        mock_address.register_uri('GET', '/schemas/hep.json', content=read_hep_schema())
+        mock_address.register_uri('GET', '/schemas/elements/titles.json', content=read_titles_schema())
+        mock_address.register_uri(
+            requests_mock.ANY,
+            re.compile('.*(indexer).*'),
+            real_http=True,
+        )
+        workflow_id = create_from_json({'records': [input_json_data]}, apply_async=False)[0]
+
+    return Workflow.query.get(workflow_id)
+
+
+def get_record_from_workflow(workflow):
+    assert len(workflow.objects) == 1
+    workflow_object = workflow.objects[0]
+
+    recid = workflow_object.data['control_number']
+    pid = PersistentIdentifier.get('recid', recid)
+
+    return Record.get_record(pid.object_uuid)

--- a/tests/responses/__init__.py
+++ b/tests/responses/__init__.py
@@ -1,3 +1,4 @@
+import json
 from os import path
 from os.path import join
 
@@ -20,3 +21,9 @@ def read_response(folder, input_filename):
     file_path = path.join(get_response_dir(), folder, input_filename)
     with open(file_path, 'rb') as f:
         return f.read()
+
+
+def read_response_as_json(folder, input_json_filename):
+    file_path = path.join(get_response_dir(), folder, input_json_filename)
+    with open(file_path, 'rt') as f:
+        return json.loads(f.read())

--- a/tests/responses/cli_fixes/test_map_old_record_remove_arxiv_prefix.json
+++ b/tests/responses/cli_fixes/test_map_old_record_remove_arxiv_prefix.json
@@ -120,6 +120,5 @@
       "date": "2019-04-27", 
       "publisher": "Springer"
     }
-  ], 
-  "record_creation_year": 2019
+  ]
 }

--- a/tests/responses/cli_fixes/test_map_old_record_remove_arxiv_prefix_expected.json
+++ b/tests/responses/cli_fixes/test_map_old_record_remove_arxiv_prefix_expected.json
@@ -120,6 +120,5 @@
       "date": "2019-04-27", 
       "publisher": "Springer"
     }
-  ], 
-  "record_creation_year": 2019
+  ]
 }

--- a/tests/responses/hepcrawl/hindawi2.json
+++ b/tests/responses/hepcrawl/hindawi2.json
@@ -106,7 +106,6 @@
         }
       ],
       "record_creation_date": "2014-01-20T00:00:00",
-      "record_creation_year": 2014,
       "titles": [
         {
           "source": "Hindawi Publishing Corporation",

--- a/tests/responses/scoap3/aps_record.json
+++ b/tests/responses/scoap3/aps_record.json
@@ -130,7 +130,6 @@
     }
   ],
   "record_creation_date": "2019-03-01T17:30:11.324880",
-  "record_creation_year": 2019,
   "titles": [
     {
       "source": "APS",

--- a/tests/unit/test_article_upload.py
+++ b/tests/unit/test_article_upload.py
@@ -169,7 +169,6 @@ def test_validate_required_fields():
                               'pubinfo_freetext': '',
                               'year': 2019}],
         'record_creation_date': '2019-04-08T14:30:41.101725',
-        'record_creation_year': 2019,
         'titles': [{'source': 'Springer',
                     'subtitle': '',
                     'title': 'Collider and gravitational wave complementarity in exploring the [...]'}]

--- a/tests/unit/test_nations.py
+++ b/tests/unit/test_nations.py
@@ -21,6 +21,13 @@ def test_countries():
 
 def test_cache():
     test_country_key = "some cached value2"
+
+    # make sure there is no cache for this key yet
+    existing_cc = CountryCache.query.get(test_country_key)
+    if existing_cc:
+        db.session.delete(existing_cc)
+        db.session.commit()
+
     test_country_value = "Noland"
     cc = CountryCache()
     cc.key = test_country_key


### PR DESCRIPTION
* Fix typo in email
* Remove `record_creation_year` field from everywhere.
* Adding automatically `year` field when indexing a record.
* Running index automatically whenever a record is committed.
* Replacing `record_creation_date` with `date` (= publication date) on UI.
* Refactoring common functions used in tests.