### PR TITLE
compliance: only send notification if final result has changed

### DIFF
--- a/scoap3/modules/compliance/compliance.py
+++ b/scoap3/modules/compliance/compliance.py
@@ -207,7 +207,7 @@ def check_compliance(obj, *args):
 
     checks = {}
 
-    # Add temporary data to evalutaion
+    # Add temporary data to evaluation
     extra_data = {'extracted_text': __extract_article_text(record)}
 
     all_checks_accepted = True
@@ -239,7 +239,7 @@ def check_compliance(obj, *args):
     db.session.commit()
 
     # send notification about failed checks
-    if not all_checks_accepted:
+    if not all_checks_accepted and c.has_final_result_changed():
         msg = TemplatedMessage(
             template_html='scoap3_compliance/admin/failed_email.html',
             subject='SCOAP3 - Compliance check',

--- a/scoap3/modules/compliance/models.py
+++ b/scoap3/modules/compliance/models.py
@@ -139,3 +139,10 @@ class Compliance(db.Model):
 
         self.results = new_results
         flag_modified(self, 'results')
+
+    def has_final_result_changed(self):
+        """
+        Returns true if there are no history entries or if the last history entry and current result
+        have different accepted value.
+        """
+        return not self.history or self.history[0]['results']['accepted'] != self.results['accepted']

--- a/tests/unit/test_compliance.py
+++ b/tests/unit/test_compliance.py
@@ -1,0 +1,45 @@
+from scoap3.modules.compliance.models import Compliance
+
+
+def test_status_change_false():
+    c = Compliance()
+    c.results = {
+        'accepted': False,
+    }
+    c.history = []
+
+    assert c.has_final_result_changed() is True
+
+
+def test_status_change_true():
+    c = Compliance()
+    c.results = {
+        'accepted': True,
+    }
+    c.history = []
+
+    assert c.has_final_result_changed() is True
+
+
+def test_status_change_history_false():
+    c = Compliance()
+    c.results = {
+        'accepted': False,
+    }
+    c.history = [
+        {'results': {'accepted': False}}
+    ]
+
+    assert c.has_final_result_changed() is False
+
+
+def test_status_change_history_true():
+    c = Compliance()
+    c.results = {
+        'accepted': True,
+    }
+    c.history = [
+        {'results': {'accepted': False}}
+    ]
+
+    assert c.has_final_result_changed() is True


### PR DESCRIPTION
In case a notification has already been sent out regarding an article, there should be another one only if the result is different.