### PR TITLE
robotupload: input in http body instead of a file

### DIFF
--- a/scoap3/config.py
+++ b/scoap3/config.py
@@ -835,8 +835,6 @@ FILES_REST_PERMISSION_FACTORY = 'scoap3.modules.records.permissions:files_permis
 ROBOTUPLOAD_FOLDER = '/tmp/robotupload'
 ROBOTUPLOAD_ALLOWED_USERS = {'127.0.0.1': ['ALL'], }
 
-ROBOTUPLOAD_ALLOWED_EXTENSIONS = ['xml']
-
 JOURNAL_PUBLISHER_MAPPING = {
     'Acta Physica Polonica B': 'Jagiellonian University',
     'Chinese Physics C': 'Institute of Physics Publishing/Chinese Academy of Sciences',

--- a/tests/integration/test_robotupload.py
+++ b/tests/integration/test_robotupload.py
@@ -22,25 +22,12 @@ def run_workflow(input_filename, request_mock):
 
     # build request mock
     class RequestMock():
-        class MockFile():
-            def __init__(self):
-                # read request data
-                self.file_data = read_response('robotupload', input_filename)
-
-            filename = input_filename
-
-            def read(self):
-                # read once to mimic original stream behaviour
-                result = self.file_data
-                self.file_data = ''
-                return result
+        def __init__(self):
+            self.data = read_response('robotupload', input_filename)
 
         headers = {'User-Agent': 'invenio_webupload', 'Host': 'localhost'}
         environ = {'REMOTE_ADDR': '127.0.0.1'}
         args = {}
-        files = {
-            'file': MockFile()
-        }
 
     # run workflow with patched request
     with patch('scoap3.modules.robotupload.views.request', RequestMock()), \

--- a/tests/unit/test_robotupload.py
+++ b/tests/unit/test_robotupload.py
@@ -54,19 +54,13 @@ def test_check_perm_invalid_journal():
         call_check_perms(journal_title, allowed_users, remote_addr)
 
 
-class MockFile():
-    def __init__(self, filename):
-        self.filename = filename
-
-
 class MockRequest():
-    def __init__(self, filename=None):
-        self.files = dict(file=MockFile(filename)) if filename else dict()
+    def __init__(self, data):
+        self.data = data
 
 
 def call_validate_request(remote_addr, allowed_users, request):
-    exts = ['xml']
-    config = dict(ROBOTUPLOAD_ALLOWED_USERS=allowed_users, ROBOTUPLOAD_ALLOWED_EXTENSIONS=exts)
+    config = dict(ROBOTUPLOAD_ALLOWED_USERS=allowed_users)
     with patch('scoap3.modules.robotupload.views.current_app', MockApp(config)),\
             patch('scoap3.modules.robotupload.views.request', request):
         validate_request(remote_addr)
@@ -75,7 +69,7 @@ def call_validate_request(remote_addr, allowed_users, request):
 def test_validate_valid():
     remote_addr = '2.2.2.2'
     allowed_users = {'2.2.2.2': ['ALL'], }
-    call_validate_request(remote_addr, allowed_users, MockRequest('data.xml'))
+    call_validate_request(remote_addr, allowed_users, MockRequest('<record></record>'))
 
 
 def test_validate_invalid_ip():
@@ -83,7 +77,7 @@ def test_validate_invalid_ip():
     allowed_users = {'2.2.2.2': ['ALL'], }
 
     with raises(InvalidUsage):
-        call_validate_request(remote_addr, allowed_users, MockRequest('data.xml'))
+        call_validate_request(remote_addr, allowed_users, MockRequest('<record></record>'))
 
 
 def test_validate_invalid_nofile():
@@ -91,12 +85,4 @@ def test_validate_invalid_nofile():
     allowed_users = {'2.2.2.2': ['ALL'], }
 
     with raises(InvalidUsage):
-        call_validate_request(remote_addr, allowed_users, MockRequest())
-
-
-def test_validate_invalid_extension():
-    remote_addr = '2.2.2.2'
-    allowed_users = {'2.2.2.2': ['ALL'], }
-
-    with raises(InvalidUsage):
-        call_validate_request(remote_addr, allowed_users, MockRequest('my.py'))
+        call_validate_request(remote_addr, allowed_users, MockRequest(''))


### PR DESCRIPTION
Change robotupload module to use http data as input instead of an attached file based on the captured packages.