### PR TITLE
workflows: fix attaching robotupload files

### DIFF
--- a/scoap3/modules/workflows/workflows/articles_upload.py
+++ b/scoap3/modules/workflows/workflows/articles_upload.py
@@ -297,7 +297,7 @@ def build_files_data(obj, eng):
             files.append(
                 {
                     'url': document['url'],
-                    'name': doi,
+                    'name': "%s.%s" % (doi, ext),
                     'filetype': ext
                 }
             )

--- a/tests/integration/test_robotupload.py
+++ b/tests/integration/test_robotupload.py
@@ -8,7 +8,7 @@ from invenio_workflows import Workflow
 from workflow.engine_db import WorkflowStatus
 
 from scoap3.modules.robotupload.views import handle_upload_request
-from tests.integration.utils import mock_halt
+from tests.integration.utils import mock_halt, get_record_from_workflow
 from tests.responses import get_response_dir, read_response
 
 
@@ -66,6 +66,10 @@ def test_robotupload_cpc():
         # test if only one workflow was created
         assert Workflow.query.count() - workflows_count == 1
 
+        record = get_record_from_workflow(workflow)
+        assert '_files' in record
+        assert len(record['_files']) == 2
+
 
 def test_robotupload_acta():
     with requests_mock.Mocker() as m:
@@ -84,3 +88,7 @@ def test_robotupload_acta():
 
         # test if only one workflow was created
         assert Workflow.query.count() - workflows_count == 1
+
+        record = get_record_from_workflow(workflow)
+        assert '_files' in record
+        assert len(record['_files']) == 2


### PR DESCRIPTION
Due to filename collision only one of the files were uploaded correctly. The already existing file got overwritten instead of having a new file created.